### PR TITLE
Increase max length of Symbol to 7 bytes (6+NULL)

### DIFF
--- a/src/ticker-scraper.h
+++ b/src/ticker-scraper.h
@@ -17,7 +17,7 @@ typedef enum MarketPlaces
     NASDAQ = (1 << 2)
 } MarketPlace;
 
-typedef char Symbol[6];
+typedef char Symbol[7];
 
 int strpos(const char *source, const char *search);
 


### PR DESCRIPTION
OIBR-C didn't fit, had to bump its length by 1 byte